### PR TITLE
Typo in Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = . examples
 BUILT_SOURCES = riemann/proto.pb-c.h riemann/proto.pb-c.c
 lib_LTLIBRARIES = libriemann_client.la
 libriemann_client_la_SOURCES = client.c  common.c  event.c  message.c  query.c  tcp.c  udp.c riemann/proto.pb-c.c
-libriemann_client_la_LD_FLAGS = -lprotobuf-c
+libriemann_client_la_LDFLAGS = -lprotobuf-c
 include_HEADERS = riemann/udp.h riemann/common.h riemann/message.h riemann/event.h riemann/tcp.h riemann/query.h riemann/client.h
 
 riemann/proto.pb-c.h riemann/proto.pb-c.c : proto.proto


### PR DESCRIPTION
libriemann_client_la_LDFLAGS is typo'd as libriemann_client_la_LD_FLAGS, which will cause automake to generate a Makefile which will not link the library against libprotobuf-c.
