### PR TITLE
Allocate space only for n_attrs number of pointers

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -150,7 +150,7 @@ void riemann_event_set_metric_d(riemann_event_t *evtp, double metric)
 int riemann_event_set_attributes(riemann_event_t *evtp, const riemann_attribute_pairs_t *apairsp, size_t n_attrs)
 {
         int i;
-        riemann_attribute_t **attrs = malloc(sizeof(riemann_attribute_t) * n_attrs);
+        riemann_attribute_t **attrs = malloc(sizeof(riemann_attribute_t *) * n_attrs);
 
         if (!attrs)
                 return -2;


### PR DESCRIPTION
Currently, we are allocating space for the entire object but accessing only the pointers allocated with that space. This modification addresses that issue making sure that we only allocate space only for the pointers that we need.
