### PR TITLE
Fix a build error on GCC 7.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ WARNING: This is in really early stages, and was not fully tested.
 
 ```
 # ./build.sh
-# ./configure --with-protobuf-c-dir=/root/usr/protobuf-c
+# ./configure --with-protobuf-c-dir=/usr/include/protobuf-c
 # make
 ```
 

--- a/src/event.c
+++ b/src/event.c
@@ -7,6 +7,8 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
+#include <riemann/_config.h>
+
 #include <stdlib.h>
 
 #if RIEMANN_HAVE_INTTYPES_H
@@ -16,7 +18,6 @@
 #include <time.h>
 #include <string.h>
 
-#include <riemann/_config.h>
 #include <riemann/attribute.h>
 #include <riemann/event.h>
 


### PR DESCRIPTION
I changed the order of an include statement.

`RIEMANN_HAVE_INTTYPES_H` wasn't defined at the time it was used, and because of this it was including inttypes.h, so it caused build errors.

I also made a fix in the documentation, `/root/usr/protobuf-c` didn't exist for me.